### PR TITLE
New: Add npm config to enforce semver range

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-prefix = '~'

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix "~"

--- a/blueprints/showbie-tooling/files/.npmrc
+++ b/blueprints/showbie-tooling/files/.npmrc
@@ -1,0 +1,1 @@
+save-prefix = '~'

--- a/blueprints/showbie-tooling/files/.yarnrc
+++ b/blueprints/showbie-tooling/files/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix "~"

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,18 +1,14 @@
-import Ember from 'ember';
-import Resolver from './resolver';
+import Application from '@ember/application';
+
 import loadInitializers from 'ember-load-initializers';
+
+import Resolver from './resolver';
 import config from './config/environment';
 
-const { Application } = Ember;
-
-let App;
-
-Ember.MODEL_FACTORY_INJECTIONS = true;
-
-App = Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver
+  Resolver,
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,14 +1,12 @@
-import Ember from 'ember';
-import config from './config/environment';
+import EmberRouter from '@ember/routing/router';
 
-const { Router: EmberRouter } = Ember;
+import config from './config/environment';
 
 const Router = EmberRouter.extend({
   location: config.locationType,
-  rootURL: config.rootURL
+  rootURL: config.rootURL,
 });
 
-Router.map(function() {
-});
+Router.map(function() {});
 
 export default Router;

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { run } = Ember;
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
   run(application, 'destroy');

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,10 +1,8 @@
-import Ember from 'ember';
 import { module } from 'qunit';
+import { Promise } from 'rsvp';
 
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,11 +1,8 @@
-import Ember from 'ember';
+import { merge } from '@ember/polyfills';
+import { run } from '@ember/runloop';
+
 import Application from '../../app';
 import config from '../../config/environment';
-
-const {
-  merge,
-  run
-} = Ember;
 
 export default function startApp(attrs) {
   let application;


### PR DESCRIPTION
Will install new packages with `~` prefix by default, instead of `^`.